### PR TITLE
Add headless Amazon login example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# amazon-bot
+# Amazon Bot
+
+This repository contains a simple Python script that uses Selenium to open a headless Chrome browser and log in to Amazon.com.
+
+## Requirements
+- Python 3.12+
+- `selenium` package
+- ChromeDriver installed and accessible via PATH
+
+Install dependencies with:
+
+```bash
+pip install selenium
+```
+
+Ensure ChromeDriver is available in your system PATH. You can download it from [ChromeDriver documentation](https://chromedriver.chromium.org/).
+
+## Usage
+Set your Amazon credentials as environment variables `AMAZON_EMAIL` and `AMAZON_PASSWORD` and run the script:
+
+```bash
+export AMAZON_EMAIL="your-email@example.com"
+export AMAZON_PASSWORD="your-password"
+python3 amazon_bot.py
+```
+
+**Warning**: Do not commit your credentials or share them publicly. The script may require additional manual steps for multi-factor authentication or CAPTCHA challenges on Amazon's login page.

--- a/amazon_bot.py
+++ b/amazon_bot.py
@@ -1,0 +1,47 @@
+import os
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+def login_amazon(email, password):
+    options = Options()
+    options.add_argument('--headless')
+    options.add_argument('--disable-gpu')
+    options.add_argument('--no-sandbox')
+
+    with webdriver.Chrome(options=options) as driver:
+        driver.get('https://www.amazon.com/ap/signin')
+        wait = WebDriverWait(driver, 10)
+
+        email_field = wait.until(EC.presence_of_element_located((By.ID, 'ap_email')))
+        email_field.send_keys(email)
+        email_field.send_keys(Keys.RETURN)
+
+        password_field = wait.until(EC.presence_of_element_located((By.ID, 'ap_password')))
+        password_field.send_keys(password)
+        password_field.send_keys(Keys.RETURN)
+
+        # wait for the page to load by checking if sign-out link is present
+        try:
+            wait.until(EC.presence_of_element_located((By.ID, 'nav-item-signout')))
+            print('Login successful.')
+        except Exception:
+            print('Login may have failed. Please check your credentials or complete any additional verification steps.')
+
+
+def main():
+    email = os.getenv('AMAZON_EMAIL')
+    password = os.getenv('AMAZON_PASSWORD')
+
+    if not email or not password:
+        raise ValueError('Set AMAZON_EMAIL and AMAZON_PASSWORD environment variables.')
+
+    login_amazon(email, password)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple Selenium script for headless login
- update README with usage instructions and credentials note

## Testing
- `pip install selenium`


------
https://chatgpt.com/codex/tasks/task_e_684113e9b4588332840dc43df1062813