### PR TITLE
Add Dockerfile with Chrome and Selenium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Use official Python runtime as a parent image
+FROM python:3.12-slim
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        wget \
+        gnupg \
+        unzip \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Google Chrome
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /usr/share/keyrings/google-chrome.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends google-chrome-stable && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install ChromeDriver matching Chrome version
+RUN CHROME_VERSION=$(google-chrome --version | awk '{print $3}' | cut -d'.' -f1) && \
+    DRIVER_VERSION=$(wget -qO- "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}") && \
+    wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/${DRIVER_VERSION}/chromedriver_linux64.zip" && \
+    unzip /tmp/chromedriver.zip -d /usr/local/bin && \
+    rm /tmp/chromedriver.zip && \
+    chmod +x /usr/local/bin/chromedriver
+
+# Install Python dependencies
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+# Copy application code
+WORKDIR /app
+COPY . /app
+
+# Default command
+CMD ["python", "amazon_bot.py"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ pip install selenium
 
 Ensure ChromeDriver is available in your system PATH. You can download it from [ChromeDriver documentation](https://chromedriver.chromium.org/).
 
+## Docker
+You can also run the bot inside a Docker container. The provided `Dockerfile` installs
+Google Chrome, ChromeDriver and the required Python packages.
+
+Build the image and run it with your Amazon credentials:
+
+```bash
+docker build -t amazon-bot .
+docker run -e AMAZON_EMAIL="your-email@example.com" \
+           -e AMAZON_PASSWORD="your-password" amazon-bot
+```
+
 ## Usage
 Set your Amazon credentials as environment variables `AMAZON_EMAIL` and `AMAZON_PASSWORD` and run the script:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+selenium


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs Google Chrome and ChromeDriver
- include a requirements file for Python packages
- document how to build and run the container

## Testing
- `python3 -m py_compile amazon_bot.py`
- `pip install selenium`
- `AMAZON_EMAIL=test@example.com AMAZON_PASSWORD=secret python3 amazon_bot.py` *(fails: Unable to obtain driver for chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684114d9b27483328acc6169aa2f253e